### PR TITLE
Updated CSS links for latest trillium

### DIFF
--- a/bear-dark.css
+++ b/bear-dark.css
@@ -88,8 +88,9 @@
   --ck-color-link-selected-background: var(--bear-selection-color);
 }
 
+/* another choice that looks nice here is icon-color.png */
 body .global-menu-button {
-  background-image: url("../../../images/icon-grey.png");
+  background-image: url("/assets/vX/images/icon-grey.png");
 }
 
 body ::-webkit-calendar-picker-indicator {

--- a/bear-white.css
+++ b/bear-white.css
@@ -88,8 +88,9 @@
   --ck-color-link-selected-background: var(--bear-selection-color);
 }
 
+/* another choice that looks nice here is icon-color.png */
 body .global-menu-button {
-  background-image: url("../../../images/icon-grey.png");
+  background-image: url("/assets/vX/images/icon-grey.png");
 }
 
 body span.fancytree-active .fancytree-title {


### PR DESCRIPTION
Reference:
https://github.com/zadam/trilium/issues/3377

This PR will restore the icon to it's original state.

Before:

![image](https://github.com/AllanZyne/trilium-bear-theme/assets/32517635/02342650-c7a5-4466-8fe4-801b8c0113da)

After:
![image](https://github.com/AllanZyne/trilium-bear-theme/assets/32517635/8b2c67ce-8b86-4656-a572-baa14f7dafb5)

Also added a comment about the colored icon because I thought it looked nice and wasn't aware of it until looking through code.
![image](https://github.com/AllanZyne/trilium-bear-theme/assets/32517635/ef3d8306-bcfe-4730-a447-eda5cf67070e)
